### PR TITLE
feat: 添加Luminee Switcher扩展包，支持动态切换数据库连接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Luminee Switcher
+
+Laravel数据库连接切换扩展包，支持动态切换默认数据库连接和添加额外连接配置。
+
+## 功能特性
+
+- 动态切换默认数据库连接
+- 支持添加额外数据库连接配置
+- 自动恢复原始连接
+- 支持多层级连接配置
+
+## 安装
+
+通过Composer安装：
+
+```bash
+composer require luminee/switcher
+```
+
+## 配置
+
+1. 发布配置文件：
+
+```bash
+php artisan vendor:publish --provider="Luminee\Switcher\SwitcherServiceProvider"
+```
+
+2. 在`config/switcher.php`中添加额外连接配置：
+
+```php
+return [
+    'extra_connections' => [
+        // 简单连接配置
+        'mysql2' => [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            // 其他配置...
+        ],
+        
+        // 多层级连接配置
+        'project' => [
+            'dev' => [
+                'driver' => 'mysql',
+                // 配置...
+            ],
+            'prod' => [
+                'driver' => 'mysql',
+                // 配置...
+            ]
+        ]
+    ]
+];
+```
+
+## 使用方法
+
+### 基本用法
+
+```php
+use Luminee\Switcher\Facades\Switcher;
+
+Switcher::run(function() {
+    // 这里使用新连接执行操作
+    return User::all();
+}, 'mysql2');
+```
+
+### 使用多层级连接
+
+```php
+Switcher::run(function() {
+    // 使用project_dev连接
+    return User::all();
+}, 'project_dev');
+```
+
+## 注意事项
+
+1. 连接切换仅在闭包函数内有效
+2. 操作完成后会自动恢复原始连接
+3. 连接名称会自动转换为小写
+4. 多层级连接会自动添加前缀（如`project_dev`）
+
+## 开源协议
+
+MIT

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "luminee/switcher",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Luminee\\Switcher\\": "src/"
+        }
+    },
+    "authors": [
+        {
+            "name": "LuminEe",
+            "email": "1123462990@qq.com"
+        }
+    ],
+    "minimum-stability": "stable",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Luminee\\Switcher\\SwitcherServiceProvider"
+            ]
+        }
+    },
+    "require": {
+        "php": ">=7.0",
+        "laravel/framework": "5.5.*"
+    }
+}

--- a/config/switcher.php
+++ b/config/switcher.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Extra Database Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define additional database connections that should be 
+    | available for switching.
+    |
+    */
+    'extra_connections' => [
+        'dev' => [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', 'localhost'),
+            'database' => env('DB_DATABASE', 'forge'),
+            'username' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix' => '',
+            'strict' => false,
+            // Like [database.connections.mysql]
+        ],
+
+        'master' => [
+            'dev' => [
+                'driver' => 'mysql',
+                'host' => env('DB_HOST', 'localhost'),
+            ],
+
+            'dev.read' => [
+                'driver' => 'mysql',
+                'host' => env('DB_HOST', 'localhost'),
+            ],
+        ],
+    ],
+];

--- a/src/Facades/Switcher.php
+++ b/src/Facades/Switcher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Luminee\Switcher\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static mixed run(Closure $command, string $connection)
+ */
+class Switcher extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'switcher';
+    }
+}

--- a/src/Switcher.php
+++ b/src/Switcher.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Luminee\Switcher;
+
+use Closure;
+use Illuminate\Database\DatabaseManager;
+
+class Switcher
+{
+    /**
+     * @var DatabaseManager
+     */
+    protected $db;
+
+    /**
+     * Bootstrap the console application.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->db = app()->get('db');
+        $this->appendExtraConnections();
+    }
+
+    protected function appendExtraConnections()
+    {
+        $extra_connections = config('switcher.extra_connections');
+
+        if (!empty($extra_connections)) {
+            app()['config']['database.connections'] = array_merge(
+                app()['config']['database.connections'],
+                $this->handleExtraConnections($extra_connections)
+            );
+        }
+    }
+
+    protected function handleExtraConnections($extra_connections)
+    {
+        $connections = [];
+        foreach ($extra_connections as $name => $config) {
+            $name = strtolower($name);
+            if ($this->isConnectionConfig($config)) {
+                $connections[$name] = $config;
+            } else {
+                foreach ($config as $conn => $connection_config) {
+                    $connections[$name . '_' . $conn] = $connection_config;
+                }
+            }
+        }
+
+        return $connections;
+    }
+
+    protected function isConnectionConfig($config)
+    {
+        foreach ($config as $value) {
+            if (!is_array($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Runs the current command.
+     *
+     * @return int 0 if everything went fine, or an error code
+     */
+    public function run(Closure $command, $connection)
+    {
+        $previousConnection = $this->db->getDefaultConnection();
+
+        $this->db->setDefaultConnection($connection);
+
+        return tap($command(), function () use ($previousConnection) {
+            $this->db->setDefaultConnection($previousConnection);
+        });
+    }
+}

--- a/src/SwitcherServiceProvider.php
+++ b/src/SwitcherServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Luminee\Switcher;
+
+use Illuminate\Support\ServiceProvider;
+use Luminee\Switcher\Switcher;
+
+class SwitcherServiceProvider extends ServiceProvider
+{
+    /**
+     * @var string
+     */
+    protected $config = __DIR__ . '/../config';
+
+    /**
+     * Boot the service provider.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([$this->config . 'switcher.php' => config_path('switcher.php')]);
+    }
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->config = realpath($this->config) . DIRECTORY_SEPARATOR;
+
+        if (file_exists($this->config . 'switcher.php')) {
+            $this->mergeConfigFrom($this->config . 'switcher.php', 'switcher');
+        }
+
+        $this->app->singleton(Switcher::class, function ($app) {
+            return new Switcher();
+        });
+
+        $this->app->alias(Switcher::class, 'switcher');
+    }
+}


### PR DESCRIPTION
添加Luminee Switcher扩展包，包含Switcher类、Facade、ServiceProvider及配置文件，支持动态切换默认数据库连接和添加额外连接配置。扩展包通过闭包函数实现连接切换，并在操作完成后自动恢复原始连接。